### PR TITLE
Fix typo: "Sciene" -> "Science"

### DIFF
--- a/constitution.tex
+++ b/constitution.tex
@@ -216,7 +216,7 @@
 \section{Dissolution of the Chapter}
 \begin{enumerate}
 	\item Dissolution of this Chapter by consent of the members shall consist of unanimous agreement of all its officers together with a majority vote at a meeting. This meeting must have been publicized at least two weeks in in advance to all members of the Chapter as for the purpose of taking this vote of dissolution.
-	\item Should the Chapter be dissolved, its assets and liabilities shall be transferred to the College of Sciene and Engineering.
+	\item Should the Chapter be dissolved, its assets and liabilities shall be transferred to the College of Science and Engineering.
 
 \end{enumerate}
 


### PR DESCRIPTION
Literally was just scrolling past and saw this typo, not a big deal.